### PR TITLE
Update outputs to play nice with Terraform 0.11

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,45 +1,101 @@
-output "private_subnets" {
-  value = ["${aws_subnet.private.*.id}"]
-}
-
-output "database_subnets" {
-  value = ["${aws_subnet.database.*.id}"]
-}
-
-output "database_subnet_group" {
-  value = "${aws_db_subnet_group.database.id}"
-}
-
-output "public_subnets" {
-  value = ["${aws_subnet.public.*.id}"]
-}
-
-output "elasticache_subnets" {
-  value = ["${aws_subnet.elasticache.*.id}"]
-}
-
-output "elasticache_subnet_group" {
-  value = "${aws_elasticache_subnet_group.elasticache.id}"
-}
-
+# VPC
 output "vpc_id" {
-  value = "${aws_vpc.mod.id}"
+  description = "The ID of the VPC"
+  value       = "${aws_vpc.mod.id}"
 }
 
 output "vpc_cidr_block" {
-  value = "${aws_vpc.mod.cidr_block}"
-}
-
-output "public_route_table_ids" {
-  value = ["${aws_route_table.public.*.id}"]
-}
-
-output "private_route_table_ids" {
-  value = ["${aws_route_table.private.*.id}"]
+  description = "The CIDR block of the VPC"
+  value       = "${aws_vpc.mod.cidr_block}"
 }
 
 output "default_security_group_id" {
-  value = "${aws_vpc.mod.default_security_group_id}"
+  description = "The ID of the security group created by default on VPC creation"
+  value       = "${aws_vpc.mod.default_security_group_id}"
+}
+
+output "default_network_acl_id" {
+  description = "The ID of the default network ACL"
+  value       = "${aws_vpc.mod.default_network_acl_id}"
+}
+
+# Subnets
+output "private_subnets" {
+  description = "List of IDs of private subnets"
+  value       = ["${aws_subnet.private.*.id}"]
+}
+
+output "private_subnets_cidr_blocks" {
+  description = "List of cidr_blocks of private subnets"
+  value       = ["${aws_subnet.private.*.cidr_block}"]
+}
+
+output "public_subnets" {
+  description = "List of IDs of public subnets"
+  value       = ["${aws_subnet.public.*.id}"]
+}
+
+output "public_subnets_cidr_blocks" {
+  description = "List of cidr_blocks of public subnets"
+  value       = ["${aws_subnet.public.*.cidr_block}"]
+}
+
+output "database_subnets" {
+  description = "List of IDs of database subnets"
+  value       = ["${aws_subnet.database.*.id}"]
+}
+
+output "database_subnets_cidr_blocks" {
+  description = "List of cidr_blocks of database subnets"
+  value       = ["${aws_subnet.database.*.cidr_block}"]
+}
+
+output "database_subnet_group" {
+  description = "ID of database subnet group"
+  value       = "${element(concat(aws_db_subnet_group.database.*.id, list("")), 0)}"
+}
+
+output "elasticache_subnets" {
+  description = "List of IDs of elasticache subnets"
+  value       = ["${aws_subnet.elasticache.*.id}"]
+}
+
+output "elasticache_subnets_cidr_blocks" {
+  description = "List of cidr_blocks of elasticache subnets"
+  value       = ["${aws_subnet.elasticache.*.cidr_block}"]
+}
+
+output "elasticache_subnet_group" {
+  description = "ID of elasticache subnet group"
+  value       = "${element(concat(aws_elasticache_subnet_group.elasticache.*.id, list("")), 0)}"
+}
+
+# Route tables
+output "public_route_table_ids" {
+  description = "List of IDs of public route tables"
+  value       = ["${aws_route_table.public.*.id}"]
+}
+
+output "private_route_table_ids" {
+  description = "List of IDs of private route tables"
+  value       = ["${aws_route_table.private.*.id}"]
+}
+
+# Internet Gateway
+output "igw_id" {
+  description = "The ID of the Internet Gateway"
+  value       = "${element(concat(aws_internet_gateway.mod.*.id, list("")), 0)}"
+}
+
+# VPC Endpoints
+output "vpc_endpoint_s3_id" {
+  description = "The ID of VPC endpoint for S3"
+  value       = "${element(concat(aws_vpc_endpoint.s3.*.id, list("")), 0)}"
+}
+
+output "vpc_endpoint_dynamodb_id" {
+  description = "The ID of VPC endpoint for DynamoDB"
+  value       = "${element(concat(aws_vpc_endpoint.dynamodb.*.id, list("")), 0)}"
 }
 
 output "nat_eips" {
@@ -52,20 +108,4 @@ output "nat_eips_public_ips" {
 
 output "natgw_ids" {
   value = ["${aws_nat_gateway.natgw.*.id}"]
-}
-
-output "igw_id" {
-  value = "${aws_internet_gateway.mod.id}"
-}
-
-output "default_network_acl_id" {
-  value = "${aws_vpc.mod.default_network_acl_id}"
-}
-
-output "vpc_endpoint_s3_id" {
-  value = "${aws_vpc_endpoint.s3.id}"
-}
-
-output "vpc_endpoint_dynamodb_id" {
-  value = "${aws_vpc_endpoint.dynamodb.id}"
 }


### PR DESCRIPTION
Terraform 0.11 has more stringent validation of module outputs:
> Output interpolation errors are now fatal. Module configs with
> unused outputs which contained errors will no longer be valid.

The upstream module is deprecated in favor of
https://github.com/terraform-aws-modules/terraform-aws-vpc

This commit adapts the outputs from the *new* upstream version of
this module so it works with Terraform >= 0.11.